### PR TITLE
🚀Release: 0.19.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# v0.19.0
+- Added `queryQueueActions` to `HorusDataFacade`.
+  - New method to query queued actions stored in the local queue (table `horus_queue_actions`).
+  - Supports filtering by:
+    - `entityNames`: list of entity names to include.
+    - `dataFilter`: map of json-extracted attributes to match against action data.
+    - `minDate` and optional `maxDate`: date range (inclusive) used with a timezone to convert to epoch seconds.
+    - `timeZone`: timezone used to convert LocalDate to epoch boundaries.
+  - Returns a list of `Horus.QueueAction` with fields `(entity, id, type)` where `type` maps to the exposed `ActionType` (INSERT, UPDATE, DELETE, MOVE).
+  - Behavior notes:
+    - If `maxDate` is `null`, the implementation uses `minDate` as the upper bound (the query matches that exact day).
+    - `dataFilter` values are compared using `json_extract(horus_queue_actions.data, '$.<key>')` in SQL.
+
 # v0.18.2
 - Fixed `ClassCastException` on iOS when reading `INTEGER` columns from SQLite (`Long` cannot be cast to `Int` in Kotlin/Native). Implemented numeric type coercion in `Cursor.getValue` using reified type parameters to handle the conversion transparently on all platforms.
 

--- a/client/src/androidUnitTest/kotlin/org/apptank/horus/client/AndroidHorusDataFacadeTest.kt
+++ b/client/src/androidUnitTest/kotlin/org/apptank/horus/client/AndroidHorusDataFacadeTest.kt
@@ -36,6 +36,12 @@ import org.apptank.horus.client.bus.HorusClientSyncErrorEventBus
 import org.apptank.horus.client.control.QueueActionsTable
 import org.apptank.horus.client.control.helper.ISyncControlDatabaseHelper
 import org.apptank.horus.client.control.SyncControl
+import org.apptank.horus.client.data.ActionType
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.serialization.encodeToString
+import org.apptank.horus.client.serialization.AnySerializer
 import org.apptank.horus.client.control.helper.IOperationDatabaseHelper
 import org.apptank.horus.client.control.scheme.DataSharedTable
 import org.apptank.horus.client.database.builder.SimpleQueryBuilder
@@ -61,13 +67,9 @@ import dev.mokkery.answering.calls
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.eq
-import dev.mokkery.matcher.matches
 import dev.mokkery.MockMode
 import dev.mokkery.mock
 import dev.mokkery.verify
-import dev.mokkery.verifySuspend
-import dev.mokkery.verify.VerifyMode.Companion.exactly
 import org.robolectric.annotation.Config
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -1132,6 +1134,305 @@ class AndroidHorusDataFacadeTest : TestCase() {
 
         // Then
         assertFalse(result)
+    }
+
+    @Test
+    fun `queryQueueActions returns empty list when no actions exist`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entityName = "measures"
+            val minDate = LocalDate(2026, 5, 22)
+            val timeZone = TimeZone.of("America/Bogota")
+
+            // When
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entityName),
+                dataFilter = emptyMap(),
+                minDate = minDate,
+                maxDate = null,
+                timeZone = timeZone
+            )
+
+            // Then
+            result.fold(
+                { queueActions ->
+                    Assert.assertTrue(queueActions.isEmpty())
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `queryQueueActions returns actions filtered by entity name`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entity1 = "measures"
+            val entity2 = "product_breeds"
+            val timeZone = TimeZone.of("America/Bogota")
+            val testDate = LocalDate(2026, 5, 22)
+            val epoch = testDate.atTime(12, 0).toInstant(timeZone).epochSeconds
+
+            // Insert actions in queue table
+            val row1 = mapOf(
+                QueueActionsTable.ATTR_ENTITY to entity1,
+                QueueActionsTable.ATTR_ACTION_TYPE to SyncControl.ActionType.INSERT.id,
+                QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to "1", "measure" to "w")),
+                QueueActionsTable.ATTR_DATETIME to epoch
+            )
+            val row2 = mapOf(
+                QueueActionsTable.ATTR_ENTITY to entity2,
+                QueueActionsTable.ATTR_ACTION_TYPE to SyncControl.ActionType.UPDATE.id,
+                QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to "2", "name" to "breed1")),
+                QueueActionsTable.ATTR_DATETIME to epoch
+            )
+
+            driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+            driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+
+            // When: Query only entity1
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entity1),
+                dataFilter = emptyMap(),
+                minDate = testDate,
+                maxDate = null,
+                timeZone = timeZone
+            )
+
+            // Then
+            result.fold(
+                { queueActions ->
+                    Assert.assertEquals(1, queueActions.size)
+                    Assert.assertEquals(entity1, queueActions[0].entity)
+                    Assert.assertEquals("1", queueActions[0].id)
+                    Assert.assertEquals(ActionType.INSERT, queueActions[0].type)
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `queryQueueActions filters by multiple entity names`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entity1 = "measures"
+            val entity2 = "product_breeds"
+            val entity3 = "other_entity"
+            val timeZone = TimeZone.of("America/Bogota")
+            val testDate = LocalDate(2026, 5, 22)
+            val epoch = testDate.atTime(12, 0).toInstant(timeZone).epochSeconds
+
+            // Insert 3 actions for different entities
+            listOf(
+                Triple(entity1, SyncControl.ActionType.INSERT, "1"),
+                Triple(entity2, SyncControl.ActionType.UPDATE, "2"),
+                Triple(entity3, SyncControl.ActionType.DELETE, "3")
+            ).forEach { (entity, actionType, id) ->
+                val row = mapOf(
+                    QueueActionsTable.ATTR_ENTITY to entity,
+                    QueueActionsTable.ATTR_ACTION_TYPE to actionType.id,
+                    QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                    QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to id, "name" to "test")),
+                    QueueActionsTable.ATTR_DATETIME to epoch
+                )
+                driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row)
+            }
+
+            // When: Query entities 1 and 2
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entity1, entity2),
+                dataFilter = emptyMap(),
+                minDate = testDate,
+                maxDate = null,
+                timeZone = timeZone
+            )
+
+            // Then
+            result.fold(
+                { queueActions ->
+                    Assert.assertEquals(2, queueActions.size)
+                    val entityNames = queueActions.map { it.entity }
+                    Assert.assertTrue(entityNames.contains(entity1))
+                    Assert.assertTrue(entityNames.contains(entity2))
+                    Assert.assertFalse(entityNames.contains(entity3))
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `queryQueueActions filters by date range`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entity = "measures"
+            val timeZone = TimeZone.of("America/Bogota")
+
+            // Create actions on different dates
+            val dates = listOf(
+                LocalDate(2026, 5, 20),
+                LocalDate(2026, 5, 21),
+                LocalDate(2026, 5, 22),
+                LocalDate(2026, 5, 23)
+            )
+
+            dates.forEach { date ->
+                val epoch = date.atTime(12, 0).toInstant(timeZone).epochSeconds
+                val row = mapOf(
+                    QueueActionsTable.ATTR_ENTITY to entity,
+                    QueueActionsTable.ATTR_ACTION_TYPE to SyncControl.ActionType.INSERT.id,
+                    QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                    QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to "id_${date.dayOfMonth}", "measure" to "w")),
+                    QueueActionsTable.ATTR_DATETIME to epoch
+                )
+                driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row)
+            }
+
+            // When: Query between 2026-05-21 and 2026-05-23 (inclusive)
+            val minDate = LocalDate(2026, 5, 21)
+            val maxDate = LocalDate(2026, 5, 23)
+
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entity),
+                dataFilter = emptyMap(),
+                minDate = minDate,
+                maxDate = maxDate,
+                timeZone = timeZone
+            )
+
+            // Then: Should return 3 actions (21, 22, 23)
+            result.fold(
+                { queueActions ->
+                    Assert.assertEquals(3, queueActions.size)
+                    val ids = queueActions.map { it.id }
+                    Assert.assertTrue(ids.contains("id_21"))
+                    Assert.assertTrue(ids.contains("id_22"))
+                    Assert.assertTrue(ids.contains("id_23"))
+                    Assert.assertFalse(ids.contains("id_20"))
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `queryQueueActions filters by minimum date only`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entity = "measures"
+            val timeZone = TimeZone.of("America/Bogota")
+
+            val dates = listOf(
+                LocalDate(2026, 5, 20),
+                LocalDate(2026, 5, 21),
+                LocalDate(2026, 5, 22)
+            )
+
+            dates.forEach { date ->
+                val epoch = date.atTime(12, 0).toInstant(timeZone).epochSeconds
+                val row = mapOf(
+                    QueueActionsTable.ATTR_ENTITY to entity,
+                    QueueActionsTable.ATTR_ACTION_TYPE to SyncControl.ActionType.INSERT.id,
+                    QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                    QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to "id_${date.dayOfMonth}", "measure" to "w")),
+                    QueueActionsTable.ATTR_DATETIME to epoch
+                )
+                driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row)
+            }
+
+            // When: Query with minDate=21 and no maxDate.
+            // When maxDate is null, the implementation uses minDate as maxDate (queries only that exact day)
+            val minDate = LocalDate(2026, 5, 21)
+
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entity),
+                dataFilter = emptyMap(),
+                minDate = minDate,
+                maxDate = null,
+                timeZone = timeZone
+            )
+
+            // Then: Should return only the action on May 21 (maxDate defaults to minDate)
+            result.fold(
+                { queueActions ->
+                    Assert.assertEquals(1, queueActions.size)
+                    Assert.assertEquals("id_21", queueActions[0].id)
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `queryQueueActions returns different action types correctly`(): Unit = runBlocking {
+        // Given
+        prepareEnvironment {
+            driver.execute("DELETE FROM ${QueueActionsTable.TABLE_NAME}")
+            val entity = "measures"
+            val timeZone = TimeZone.of("America/Bogota")
+            val testDate = LocalDate(2026, 5, 22)
+            val epoch = testDate.atTime(12, 0).toInstant(timeZone).epochSeconds
+
+            // Insert actions with different types
+            val actionTypes = listOf(
+                SyncControl.ActionType.INSERT,
+                SyncControl.ActionType.UPDATE,
+                SyncControl.ActionType.DELETE,
+                SyncControl.ActionType.MOVE
+            )
+
+            actionTypes.forEachIndexed { index, actionType ->
+                val row = mapOf(
+                    QueueActionsTable.ATTR_ENTITY to entity,
+                    QueueActionsTable.ATTR_ACTION_TYPE to actionType.id,
+                    QueueActionsTable.ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+                    QueueActionsTable.ATTR_DATA to AnySerializer.decoderJSON.encodeToString(mapOf("id" to "id_$index", "measure" to "w")),
+                    QueueActionsTable.ATTR_DATETIME to epoch
+                )
+                driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row)
+            }
+
+            // When
+            val result = HorusDataFacade.queryQueueActions(
+                entityNames = listOf(entity),
+                dataFilter = emptyMap(),
+                minDate = testDate,
+                maxDate = null,
+                timeZone = timeZone
+            )
+
+            // Then
+            result.fold(
+                { queueActions ->
+                    Assert.assertEquals(4, queueActions.size)
+                    Assert.assertTrue(queueActions.any { it.type == ActionType.INSERT })
+                    Assert.assertTrue(queueActions.any { it.type == ActionType.UPDATE })
+                    Assert.assertTrue(queueActions.any { it.type == ActionType.DELETE })
+                    Assert.assertTrue(queueActions.any { it.type == ActionType.MOVE })
+                },
+                { exception ->
+                    Assert.fail(exception.message)
+                }
+            )
+        }
     }
 
     //---------------------------------------------

--- a/client/src/androidUnitTest/kotlin/org/apptank/horus/client/control/SyncControlDatabaseHelperTest.kt
+++ b/client/src/androidUnitTest/kotlin/org/apptank/horus/client/control/SyncControlDatabaseHelperTest.kt
@@ -3,6 +3,7 @@ package org.apptank.horus.client.control
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
 import org.apptank.horus.client.TestCase
 import org.apptank.horus.client.control.scheme.SyncControlTable
 import org.apptank.horus.client.data.Horus
@@ -20,6 +21,18 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import kotlin.random.Random
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.encodeToString
+import org.apptank.horus.client.control.QueueActionsTable.ATTR_ACTION_TYPE
+import org.apptank.horus.client.control.QueueActionsTable.ATTR_DATA
+import org.apptank.horus.client.control.QueueActionsTable.ATTR_DATETIME
+import org.apptank.horus.client.control.QueueActionsTable.ATTR_ENTITY
+import org.apptank.horus.client.control.QueueActionsTable.ATTR_STATUS
+import org.apptank.horus.client.serialization.AnySerializer
 
 
 class SyncControlDatabaseHelperTest : TestCase() {
@@ -141,7 +154,8 @@ class SyncControlDatabaseHelperTest : TestCase() {
         )
 
         // When
-        val lastDatetimeCheckpoint = controlManagerDatabaseHelper.getLastDatetimeCheckpoint(SyncControl.OperationType.INITIAL_SYNCHRONIZATION)
+        val lastDatetimeCheckpoint =
+            controlManagerDatabaseHelper.getLastDatetimeCheckpoint(SyncControl.OperationType.INITIAL_SYNCHRONIZATION)
         // Then
         Assert.assertNotEquals(0L, lastDatetimeCheckpoint)
     }
@@ -528,27 +542,28 @@ class SyncControlDatabaseHelperTest : TestCase() {
 
 
     @Test
-    fun `when getEntitiesRelated from entity child then return parent entities related`(): Unit = runBlocking {
-        // Given
-        val entityParent = "entity_parent"
-        val entityChild = "entity_child"
+    fun `when getEntitiesRelated from entity child then return parent entities related`(): Unit =
+        runBlocking {
+            // Given
+            val entityParent = "entity_parent"
+            val entityChild = "entity_child"
 
-        driver.execute("CREATE TABLE $entityParent (id TEXT PRIMARY KEY, name TEXT)")
-        driver.execute("CREATE TABLE $entityChild (id TEXT PRIMARY KEY, parent_id TEXT, name TEXT, FOREIGN KEY(parent_id) REFERENCES $entityParent(id))")
+            driver.execute("CREATE TABLE $entityParent (id TEXT PRIMARY KEY, name TEXT)")
+            driver.execute("CREATE TABLE $entityChild (id TEXT PRIMARY KEY, parent_id TEXT, name TEXT, FOREIGN KEY(parent_id) REFERENCES $entityParent(id))")
 
-        driver.registerEntity(entityParent, level = 0)
-        driver.registerEntity(entityChild, level = 1)
+            driver.registerEntity(entityParent, level = 0)
+            driver.registerEntity(entityChild, level = 1)
 
-        // When
-        controlManagerDatabaseHelper.getEntitiesRelated(entityChild) // First call to load cache
-        val relatedEntities = controlManagerDatabaseHelper.getEntitiesRelated(entityChild)
+            // When
+            controlManagerDatabaseHelper.getEntitiesRelated(entityChild) // First call to load cache
+            val relatedEntities = controlManagerDatabaseHelper.getEntitiesRelated(entityChild)
 
 
-        // Then
-        Assert.assertEquals(1, relatedEntities.size)
-        Assert.assertEquals(entityParent, relatedEntities.first().entity)
-        Assert.assertEquals("parent_id", relatedEntities.first().attributesLinked.first())
-    }
+            // Then
+            Assert.assertEquals(1, relatedEntities.size)
+            Assert.assertEquals(entityParent, relatedEntities.first().entity)
+            Assert.assertEquals("parent_id", relatedEntities.first().attributesLinked.first())
+        }
 
     @Test
     fun `when insertActionSequences simple is success`(): Unit = runBlocking {
@@ -599,7 +614,8 @@ class SyncControlDatabaseHelperTest : TestCase() {
         val sequencesToCheck = sequences.take(30) + generateArray(20) { Random.nextLong() }
 
         // When
-        val existsSequences = controlManagerDatabaseHelper.getExistsActionSequences(sequencesToCheck)
+        val existsSequences =
+            controlManagerDatabaseHelper.getExistsActionSequences(sequencesToCheck)
 
         // Then
         Assert.assertEquals(30, existsSequences.size)
@@ -607,4 +623,410 @@ class SyncControlDatabaseHelperTest : TestCase() {
             Assert.assertTrue(existsSequences.contains(it))
         }
     }
+
+
+    @Test
+    fun `when queryActions with timezone then filter by date correctly`(): Unit = runBlocking {
+        // Given
+        val e1 = "products_q1"
+        val e2 = "orders_q1"
+
+        driver.createTable(e1, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.createTable(e2, mapOf("id" to "TEXT", "name" to "TEXT"))
+
+        driver.registerEntity(e1)
+        driver.registerEntity(e2)
+
+        val row1 = QueueActionsTable.mapToCreate(
+            SyncControl.ActionType.INSERT,
+            e1,
+            mapOf("id" to "1", "name" to "P1")
+        )
+        val row2 = QueueActionsTable.mapToCreate(
+            SyncControl.ActionType.INSERT,
+            e2,
+            mapOf("id" to "2", "name" to "O1")
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+
+        // When: query using Bogotá timezone for today (2026-05-23)
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+        val todayBogota = Clock.System.now().toLocalDateTime(timeZoneBogota).date
+
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(e1),
+            emptyMap(),
+            todayBogota,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only e1 entity
+        Assert.assertEquals(1, result.size)
+        Assert.assertEquals(e1, result.first().entity)
+
+        // Verify the epoch is correctly calculated for Bogotá end of day
+        // End of day 2026-05-23 in Bogotá = 2026-05-24 04:59:59 UTC = epoch 1779512399
+        val endOfDayBogota = todayBogota.atTime(23, 59, 59).toInstant(timeZoneBogota)
+        Assert.assertEquals(1779512399L, endOfDayBogota.epochSeconds)
+    }
+
+    @Test
+    fun queryActions_filtersByEntityNames() {
+        // Given
+        val e1 = "products_q1"
+        val e2 = "orders_q1"
+
+        driver.createTable(e1, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.createTable(e2, mapOf("id" to "TEXT", "name" to "TEXT"))
+
+        driver.registerEntity(e1)
+        driver.registerEntity(e2)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+        val testDate = LocalDate(2026, 5, 22)
+        val epoch = testDate.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        val row1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            e1,
+            mapOf("id" to "1", "name" to "P1"),
+            epoch
+        )
+        val row2 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            e2,
+            mapOf("id" to "2", "name" to "O1"),
+            epoch
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+
+        // When: query only e1 entities
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(e1),
+            emptyMap(),
+            testDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only e1 entity
+        Assert.assertEquals(1, result.size)
+        Assert.assertEquals(e1, result.first().entity)
+        Assert.assertEquals("1", result.first().data["id"])
+    }
+
+    @Test
+    fun queryActions_filtersByDateRange() {
+        // Given
+        val entity = "entity_dates_q"
+        driver.createTable(entity, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.registerEntity(entity)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+
+        // Create actions on different dates
+
+        listOf(
+            LocalDate(2026, 5, 20),
+            LocalDate(2026, 5, 21),
+            LocalDate(2026, 5, 22),
+            LocalDate(2026, 5, 23)
+        ).forEach {
+            val epoch = it.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+            val row = queueActionMapToCreate(
+                SyncControl.ActionType.INSERT,
+                entity,
+                mapOf("id" to "1", "name" to "Before"),
+                epoch
+            )
+            driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row)
+        }
+
+        // When: query between 2026-05-21 and 2026-05-23 (inclusive)
+        val minDate = LocalDate(2026, 5, 21)
+        val maxDate = LocalDate(2026, 5, 23)
+
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            emptyMap(),
+            minDate,
+            maxDate,
+            timeZoneBogota
+        )
+
+
+        Assert.assertEquals(3, result.size)
+    }
+
+    @Test
+    fun queryActions_filtersByMinDateOnly() {
+        // Given
+        val entity = "entity_min_date"
+        driver.createTable(entity, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.registerEntity(entity)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+
+        val date1 = LocalDate(2026, 5, 20)
+        val date2 = LocalDate(2026, 5, 22)
+
+        val epoch1 = date1.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+        val epoch2 = date2.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        val row1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "1", "name" to "Before"),
+            epoch1
+        )
+        val row2 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "2", "name" to "After"),
+            epoch2
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+
+        val minDate = LocalDate(2026, 5, 21)
+
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            emptyMap(),
+            minDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only row2 (2026-05-22) since it's after 2026-05-21
+        Assert.assertEquals(0, result.size)
+    }
+
+    @Test
+    fun queryActions_filtersByDataFilter_stringValue() {
+        // Given
+        val entity = "entity_filter_string"
+        driver.createTable(entity, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.registerEntity(entity)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+        val testDate = LocalDate(2026, 5, 22)
+        val epoch = testDate.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        val row1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "1", "name" to "John"),
+            epoch
+        )
+        val row2 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "2", "name" to "Alice"),
+            epoch
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+
+        // When: filter by name = "John"
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            mapOf("name" to "John"),
+            testDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only row1
+        Assert.assertEquals(1, result.size)
+        Assert.assertEquals("John", result.first().data["name"])
+        Assert.assertEquals("1", result.first().data["id"])
+    }
+
+    @Test
+    fun queryActions_filtersByDataFilter_booleanValue() {
+        // Given
+        val entity = "entity_filter_boolean"
+        driver.createTable(entity, mapOf("id" to "TEXT", "active" to "BOOLEAN"))
+        driver.registerEntity(entity)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+        val testDate = LocalDate(2026, 5, 22)
+        val epoch = testDate.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        val rowTrue = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "1", "active" to true),
+            epoch
+        )
+        val rowFalse = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "2", "active" to false),
+            epoch
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, rowTrue)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, rowFalse)
+
+        // When: filter by active = true
+        val resultTrue = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            mapOf("active" to true),
+            testDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only row with active = true
+        Assert.assertEquals(1, resultTrue.size)
+        Assert.assertEquals(true, resultTrue.first().data["active"])
+        Assert.assertEquals("1", resultTrue.first().data["id"])
+
+        // When: filter by active = false
+        val resultFalse = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            mapOf("active" to false),
+            testDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only row with active = false
+        Assert.assertEquals(1, resultFalse.size)
+        Assert.assertEquals(false, resultFalse.first().data["active"])
+        Assert.assertEquals("2", resultFalse.first().data["id"])
+    }
+
+    @Test
+    fun queryActions_filtersByMultipleDataFilters() {
+        // Given
+        val entity = "entity_multi_filter"
+        driver.createTable(entity, mapOf("id" to "TEXT", "name" to "TEXT", "active" to "BOOLEAN"))
+        driver.registerEntity(entity)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+        val testDate = LocalDate(2026, 5, 22)
+        val epoch = testDate.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        val row1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "1", "name" to "John", "active" to true),
+            epoch
+        )
+        val row2 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "2", "name" to "John", "active" to false),
+            epoch
+        )
+        val row3 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            entity,
+            mapOf("id" to "3", "name" to "Alice", "active" to true),
+            epoch
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row2)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, row3)
+
+        // When: filter by name = "John" AND active = true
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(entity),
+            mapOf("name" to "John", "active" to true),
+            testDate,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find only row1
+        Assert.assertEquals(1, result.size)
+        Assert.assertEquals("John", result.first().data["name"])
+        Assert.assertEquals(true, result.first().data["active"])
+        Assert.assertEquals("1", result.first().data["id"])
+    }
+
+    @Test
+    fun queryActions_filtersByMultipleEntitiesAndDateRange() {
+        // Given
+        val e1 = "products_multi"
+        val e2 = "orders_multi"
+        driver.createTable(e1, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.createTable(e2, mapOf("id" to "TEXT", "name" to "TEXT"))
+        driver.registerEntity(e1)
+        driver.registerEntity(e2)
+
+        val timeZoneBogota = TimeZone.of("America/Bogota")
+
+        val date1 = LocalDate(2026, 5, 20)
+        val date2 = LocalDate(2026, 5, 22)
+
+        val epoch1 = date1.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+        val epoch2 = date2.atTime(12, 0).toInstant(timeZoneBogota).epochSeconds
+
+        // Products on date1 and date2
+        val p1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            e1,
+            mapOf("id" to "p1", "name" to "Product1"),
+            epoch1
+        )
+        val p2 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            e1,
+            mapOf("id" to "p2", "name" to "Product2"),
+            epoch2
+        )
+
+        // Orders on date2
+        val o1 = queueActionMapToCreate(
+            SyncControl.ActionType.INSERT,
+            e2,
+            mapOf("id" to "o1", "name" to "Order1"),
+            epoch2
+        )
+
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, p1)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, p2)
+        driver.insertOrThrow(QueueActionsTable.TABLE_NAME, o1)
+
+        // When: query both entities from date2 only
+        val result = controlManagerDatabaseHelper.queryActions(
+            listOf(e1, e2),
+            emptyMap(),
+            date2,
+            null,
+            timeZoneBogota
+        )
+
+        // Then: should find p2 and o1 (both on date2)
+        Assert.assertEquals(2, result.size)
+        val ids = result.map { it.data["id"] as String }.sorted()
+        Assert.assertEquals(listOf("o1", "p2"), ids)
+    }
+
+
+    private fun queueActionMapToCreate(
+        actionType: SyncControl.ActionType,
+        entity: String,
+        jsonData: Map<String, Any?>,
+        datetime: Long
+    ) = mapOf(
+        ATTR_ACTION_TYPE to actionType.id,
+        ATTR_ENTITY to entity,
+        ATTR_DATA to AnySerializer.decoderJSON.encodeToString(jsonData),
+        ATTR_STATUS to SyncControl.ActionStatus.PENDING.id,
+        ATTR_DATETIME to datetime
+    )
+
 }

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/HorusDataFacade.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/HorusDataFacade.kt
@@ -1,6 +1,8 @@
 package org.apptank.horus.client
 
 import com.russhwolf.settings.Settings
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
 import org.apptank.horus.client.auth.HorusAuthentication
 import org.apptank.horus.client.base.Callback
 import org.apptank.horus.client.base.CallbackEvent
@@ -26,6 +28,7 @@ import org.apptank.horus.client.bus.InternalEventBus
 import org.apptank.horus.client.bus.EventType
 import org.apptank.horus.client.bus.HorusClientSyncErrorEventBus
 import org.apptank.horus.client.bus.SyncError
+import org.apptank.horus.client.data.toTypeExpose
 import org.apptank.horus.client.exception.AttributeRestrictedException
 import org.apptank.horus.client.exception.EntityNotExistsException
 import org.apptank.horus.client.exception.EntityNotWritableException
@@ -194,7 +197,8 @@ object HorusDataFacade {
             // --- Prepare batch: INSERT
             val (recordInserts, insertIds) = prepareInsertBatch(batch.filterIsInstance<Horus.Batch.Insert>())
             // --- Prepare batch: UPDATE
-            val (recordUpdates, updateIds) = prepareUpdateBatch(batch.filterIsInstance<Horus.Batch.Update>(),
+            val (recordUpdates, updateIds) = prepareUpdateBatch(
+                batch.filterIsInstance<Horus.Batch.Update>(),
                 insertIds.map { Horus.Entity(it.second, it.third) }
                     .associateBy { it.getRequireString(Horus.Attribute.ID) })
             // --- Prepare batch: DELETE
@@ -221,7 +225,10 @@ object HorusDataFacade {
                 processPostInsertActions(insertIds)
                 processPostUpdateActions(updateIds)
                 deleteIds.forEach { (entity, id) ->
-                    syncControlDatabaseHelper?.addActionDelete(entity, Horus.Attribute(Horus.Attribute.ID, id))
+                    syncControlDatabaseHelper?.addActionDelete(
+                        entity,
+                        Horus.Attribute(Horus.Attribute.ID, id)
+                    )
                 }
             }
             if (result == true) {
@@ -298,7 +305,8 @@ object HorusDataFacade {
             return DataResult.Failure(IllegalStateException("Attribute restricted"))
         }
 
-        val uuid = attributes.find { it.name == Horus.Attribute.ID }?.value as? String ?: generateUUID()
+        val uuid =
+            attributes.find { it.name == Horus.Attribute.ID }?.value as? String ?: generateUUID()
         val id = Horus.Attribute(Horus.Attribute.ID, uuid)
         val effectiveUserId = getEntityUserOwnerId(entity, attributes)
 
@@ -374,7 +382,8 @@ object HorusDataFacade {
         }
 
         return runCatching {
-            val result = operationDatabaseHelper?.updateWithTransaction(recordUpdates, onUpdateActions)
+            val result =
+                operationDatabaseHelper?.updateWithTransaction(recordUpdates, onUpdateActions)
             if (result.isTrue()) {
                 return@runCatching DataResult.Success(Unit)
             }
@@ -602,7 +611,10 @@ object HorusDataFacade {
     /**
      * Retrieves the count of records from entity based on the specified conditions.
      */
-    suspend fun countRecordFromEntity(entity: String, vararg whereCondition: SQL.WhereCondition): DataResult<Int> {
+    suspend fun countRecordFromEntity(
+        entity: String,
+        vararg whereCondition: SQL.WhereCondition
+    ): DataResult<Int> {
 
         return kotlin.runCatching {
 
@@ -725,8 +737,8 @@ object HorusDataFacade {
                 )
             }
         }
-        callbackSyncPushSuccess = { onSuccess?.invoke();removeListeners.invoke() }
-        callbackSyncPushFailure = { onFailure?.invoke();removeListeners.invoke() }
+        callbackSyncPushSuccess = { onSuccess?.invoke(); removeListeners.invoke() }
+        callbackSyncPushFailure = { onFailure?.invoke(); removeListeners.invoke() }
 
         with(controlTaskManager) {
             setOnCallbackStatusListener {
@@ -802,7 +814,8 @@ object HorusDataFacade {
      */
     fun uploadFile(fileData: FileData): Horus.FileReference {
         validateIsReady()
-        return uploadFileRepository?.createFileLocal(fileData) ?: throw IllegalStateException("Upload file repository is not initialized")
+        return uploadFileRepository?.createFileLocal(fileData)
+            ?: throw IllegalStateException("Upload file repository is not initialized")
     }
 
     /**
@@ -867,7 +880,9 @@ object HorusDataFacade {
                     SQL.WhereCondition(
                         SQL.ColumnValue(
                             DataSharedTable.ATTR_DATA,
-                            "%\"${attribute.name}\":%${attribute.value.prepareSQLValueAsString().replace("'", "")}%"
+                            "%\"${attribute.name}\":%${
+                                attribute.value.prepareSQLValueAsString().replace("'", "")
+                            }%"
                         ),
                         SQL.Comparator.LIKE
                     )
@@ -897,6 +912,47 @@ object HorusDataFacade {
         return isReady
     }
 
+
+    /**
+     * Queries the sync queue filtering by entities, data and a date range.
+     *
+     * @param entityNames List of entity names to query.
+     * @param dataFilter Map of data filters (key -> value) applied to the actions.
+     * @param minDate Minimum date (inclusive) of the range to query.
+     * @param maxDate Maximum date (inclusive) of the range to query; if `null` there is no upper bound.
+     * @param timeZone Time zone used to interpret the dates.
+     * @return A [DataResult] with the list of [Horus.QueueAction] found or [DataResult.Failure] in case of error.
+     */
+    suspend fun queryQueueActions(
+        entityNames: List<String>,
+        dataFilter: Map<String, Any?>,
+        minDate: LocalDate,
+        maxDate: LocalDate?,
+        timeZone: TimeZone
+    ): DataResult<List<Horus.QueueAction>> {
+
+        return runCatching {
+            val result = syncControlDatabaseHelper?.queryActions(
+                entityNames,
+                dataFilter,
+                minDate,
+                maxDate,
+                timeZone
+            ) ?: emptyList()
+
+            DataResult.Success(result.map {
+                Horus.QueueAction(
+                    it.entity,
+                    it.getEntityId(),
+                    it.action.toTypeExpose()
+                )
+            })
+
+        }.getOrElse {
+            DataResult.Failure(it)
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Private methods
     // ---------------------------------------------------------------------------------------------
@@ -913,7 +969,8 @@ object HorusDataFacade {
 
         val recordInserts = mutableListOf<DatabaseOperation.InsertRecord>()
         // ID, entity, attributes
-        val insertIds = mutableListOf<Triple<Horus.Attribute<String>, String, List<Horus.Attribute<*>>>>()
+        val insertIds =
+            mutableListOf<Triple<Horus.Attribute<String>, String, List<Horus.Attribute<*>>>>()
 
         val batchGroupedByEntity = batch.groupBy { it.entity }
 
@@ -974,7 +1031,8 @@ object HorusDataFacade {
     ): Pair<List<DatabaseOperation.UpdateRecord>, List<Triple<Horus.Attribute<String>, String, List<Horus.Attribute<*>>>>> {
 
         val recordUpdates = mutableListOf<DatabaseOperation.UpdateRecord>()
-        val updateIds = mutableListOf<Triple<Horus.Attribute<String>, String, List<Horus.Attribute<*>>>>()
+        val updateIds =
+            mutableListOf<Triple<Horus.Attribute<String>, String, List<Horus.Attribute<*>>>>()
 
         // Prepare update actions
         batch.forEach { it ->
@@ -1189,13 +1247,16 @@ object HorusDataFacade {
             return HorusAuthentication.getUserAuthenticatedId() ?: getEffectiveUserId()
         }
 
-        val entitiesRelated = syncControlDatabaseHelper?.getEntitiesRelated(entityName) ?: emptyList()
+        val entitiesRelated =
+            syncControlDatabaseHelper?.getEntitiesRelated(entityName) ?: emptyList()
 
         entitiesRelated.forEach { entityRelated ->
 
             entityRelated.attributesLinked.forEach forEachAttributes@{ attributeLinked ->
 
-                val entityRelatedId = (attributes.find { it.name == attributeLinked }?.value as? String?) ?: return@forEachAttributes
+                val entityRelatedId =
+                    (attributes.find { it.name == attributeLinked }?.value as? String?)
+                        ?: return@forEachAttributes
 
                 val relatedInBatch = insertBatchPending.find {
                     it.entity == entityRelated.entity && it.getAttribute<String>(Horus.Attribute.ID) == entityRelatedId
@@ -1203,10 +1264,17 @@ object HorusDataFacade {
 
                 // If the related entity is in the batch, we must to try to get the owner ID from entities with upper level
                 if (relatedInBatch != null) {
-                    return getEntityUserOwnerId(entityRelated.entity, relatedInBatch.attributes, insertBatchPending)
+                    return getEntityUserOwnerId(
+                        entityRelated.entity,
+                        relatedInBatch.attributes,
+                        insertBatchPending
+                    )
                 }
 
-                getEntityUserOwnerIdFromDatabase(entityRelated.entity, entityRelatedId)?.let { ownerId ->
+                getEntityUserOwnerIdFromDatabase(
+                    entityRelated.entity,
+                    entityRelatedId
+                )?.let { ownerId ->
                     return ownerId
                 }
 
@@ -1256,9 +1324,10 @@ object HorusDataFacade {
         }
 
         // Try to get the owner ID from entity related
-        operationDatabaseHelper?.queryRecords(queryBuilder)?.map { it[Horus.Attribute.OWNER_ID]?.toString() }?.firstOrNull()?.let {
-            return it
-        }
+        operationDatabaseHelper?.queryRecords(queryBuilder)
+            ?.map { it[Horus.Attribute.OWNER_ID]?.toString() }?.firstOrNull()?.let {
+                return it
+            }
 
         return null
     }

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/control/helper/ISyncControlDatabaseHelper.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/control/helper/ISyncControlDatabaseHelper.kt
@@ -1,5 +1,7 @@
 package org.apptank.horus.client.control.helper
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
 import org.apptank.horus.client.control.SyncControl
 import org.apptank.horus.client.control.model.EntityRelated
 import org.apptank.horus.client.data.Horus
@@ -197,4 +199,23 @@ interface ISyncControlDatabaseHelper {
      * @return A list of existing action sequence numbers.
      */
     fun getExistsActionSequences(sequences: List<Long>): List<Long>
+
+
+    /**
+     * Queries the database for actions that match the specified criteria.
+     *
+     * @param entityNames A list of entity names to filter actions by.
+     * @param dataFilter A map of data attributes to filter actions by.
+     * @param minDate The minimum local date to filter actions by.
+     * @param maxDate An optional maximum local date to filter actions by.
+     * @param timeZone The time zone to use for date filtering.
+     * @return A list of synchronization actions that match the specified criteria.
+     */
+    fun queryActions(
+        entityNames: List<String>,
+        dataFilter: Map<String, Any?>,
+        minDate: LocalDate,
+        maxDate: LocalDate? = null,
+        timeZone: TimeZone
+    ): List<SyncControl.Action>
 }

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/DataSharedTable.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/DataSharedTable.kt
@@ -1,6 +1,6 @@
 package org.apptank.horus.client.control.scheme
 
-object DataSharedTable {
+internal object DataSharedTable {
 
     const val TABLE_NAME = "horus_data_shared"
 

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/EntityAttributesTable.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/EntityAttributesTable.kt
@@ -8,7 +8,7 @@ import org.apptank.horus.client.migration.domain.AttributeType
  * @author John Ospina
  * @year 2024
  */
-object EntityAttributesTable {
+internal object EntityAttributesTable {
 
     const val TABLE_NAME = "horus_entity_attributes"
 

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/QueueActionsSequenceTable.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/control/scheme/QueueActionsSequenceTable.kt
@@ -3,7 +3,7 @@ package org.apptank.horus.client.control.scheme
 /**
  * Defines the schema and utility functions for the `sync_control_sequence` table.
  */
-object QueueActionsSequenceTable {
+internal object QueueActionsSequenceTable {
 
     const val TABLE_NAME = "horus_queue_actions_sequence"
 

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/data/Horus.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/data/Horus.kt
@@ -1,6 +1,7 @@
 package org.apptank.horus.client.data
 
 import org.apptank.horus.client.base.DataMap
+import org.apptank.horus.client.control.SyncControl
 import kotlin.random.Random
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -366,5 +367,28 @@ sealed class Horus {
                 return Point(latitude, longitude)
             }
         }
+    }
+
+    data class QueueAction(
+        val entity: String,
+        val id: String,
+        val type: ActionType
+    )
+}
+
+
+enum class ActionType(val id: Int) {
+    INSERT(1),
+    UPDATE(2),
+    DELETE(3),
+    MOVE(4);
+}
+
+fun SyncControl.ActionType.toTypeExpose(): ActionType {
+    return when (this) {
+        SyncControl.ActionType.INSERT -> ActionType.INSERT
+        SyncControl.ActionType.UPDATE -> ActionType.UPDATE
+        SyncControl.ActionType.DELETE -> ActionType.DELETE
+        SyncControl.ActionType.MOVE -> ActionType.MOVE
     }
 }

--- a/client/src/commonMain/kotlin/org/apptank/horus/client/database/SyncControlDatabaseHelper.kt
+++ b/client/src/commonMain/kotlin/org/apptank/horus/client/database/SyncControlDatabaseHelper.kt
@@ -13,9 +13,12 @@ import org.apptank.horus.client.bus.Event
 import org.apptank.horus.client.bus.InternalEventBus
 import org.apptank.horus.client.bus.EventType
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-import org.apptank.horus.client.cache.MemoryCache
 import org.apptank.horus.client.control.QueueActionsTable
 import org.apptank.horus.client.control.SyncControl
 import org.apptank.horus.client.control.helper.ISyncControlDatabaseHelper
@@ -24,7 +27,6 @@ import org.apptank.horus.client.control.scheme.QueueActionsSequenceTable
 import org.apptank.horus.client.control.scheme.SyncControlTable
 import org.apptank.horus.client.database.struct.Cursor
 import org.apptank.horus.client.database.struct.SQL
-import org.apptank.horus.client.extensions.execute
 import org.apptank.horus.client.migration.domain.AttributeType
 
 /**
@@ -362,7 +364,8 @@ internal class SyncControlDatabaseHelper(
      */
     override fun getEntityLevel(entityName: String): Int {
         return entityLevelCache.getOrPut(entityName) {
-            getTableEntities().find { it.name == entityName }?.level ?: throw IllegalArgumentException("Entity $entityName does not exist")
+            getTableEntities().find { it.name == entityName }?.level
+                ?: throw IllegalArgumentException("Entity $entityName does not exist")
         }
     }
 
@@ -475,9 +478,77 @@ internal class SyncControlDatabaseHelper(
                 .select(QueueActionsSequenceTable.ATTR_SEQUENCE)
                 .build()
 
-            return queryResult(sqlSentence) { it.getValue<String>(QueueActionsSequenceTable.ATTR_SEQUENCE).toLong() }
+            return queryResult(sqlSentence) {
+                it.getValue<String>(QueueActionsSequenceTable.ATTR_SEQUENCE).toLong()
+            }
         }
     }
+
+    /**
+     * Queries the database for actions that match the specified criteria.
+     *
+     * @param entityNames A list of entity names to filter actions by.
+     * @param dataFilter A map of data attributes to filter actions by.
+     * @param minDate The minimum local date to filter actions by.
+     * @param maxDate An optional maximum local date to filter actions by.
+     * @param timeZone The time zone to be used for date filtering.
+     *
+     * @return A list of synchronization actions that match the specified criteria.
+     */
+    override fun queryActions(
+        entityNames: List<String>,
+        dataFilter: Map<String, Any?>,
+        minDate: LocalDate,
+        maxDate: LocalDate?,
+        timeZone: TimeZone
+    ): List<SyncControl.Action> {
+        driver.handle {
+            // Convert LocalDate to epoch (seconds) respecting the timezone
+            val minEpoch = minDate.atStartOfDayIn(timeZone).epochSeconds
+            val maxEpoch = (maxDate ?: minDate).atEndOfDayIn(timeZone).epochSeconds
+
+            val queryBuilder = SimpleQueryBuilder(QueueActionsTable.TABLE_NAME)
+                .whereIn(QueueActionsTable.ATTR_ENTITY, entityNames)
+                .where(
+                    SQL.WhereCondition(
+                        SQL.ColumnValue(
+                            QueueActionsTable.ATTR_DATETIME,
+                            minEpoch
+                        ),
+                        SQL.Comparator.GREATER_THAN_OR_EQUALS
+                    )
+                )
+
+            queryBuilder.where(
+                SQL.WhereCondition(
+                    SQL.ColumnValue(
+                        QueueActionsTable.ATTR_DATETIME,
+                        maxEpoch
+                    ),
+                    SQL.Comparator.LESS_THAN_OR_EQUALS
+                )
+            )
+
+            dataFilter.forEach { (key, value) ->
+                queryBuilder.where(
+                    SQL.WhereCondition(
+                        SQL.ColumnValue(
+                            "json_extract(" + QueueActionsTable.ATTR_DATA + ", '\$.$key')",
+                            value
+                        )
+                    )
+                )
+            }
+
+            val sqlSentence = queryBuilder.build()
+
+            return queryResult(sqlSentence) { createSyncActionFromCursor(it) }
+        }
+    }
+
+    //-----------------------------------------------------------
+    // Private helper methods
+    //-----------------------------------------------------------
 
     /**
      * Creates a `SyncControl.Action` object from a database cursor.
@@ -571,7 +642,15 @@ internal class SyncControlDatabaseHelper(
      * @param id The identifier of the entity.
      */
     private fun emitEntityDeleted(entity: String, id: String) {
-        InternalEventBus.emit(EventType.ENTITY_DELETED, Event(mutableMapOf("entity" to entity, "id" to id)))
+        InternalEventBus.emit(
+            EventType.ENTITY_DELETED,
+            Event(mutableMapOf("entity" to entity, "id" to id))
+        )
+    }
+
+    private fun LocalDate.atEndOfDayIn(timeZone: TimeZone): Instant {
+        val localDateTime = this.atTime(23, 59, 59)
+        return localDateTime.toInstant(timeZone)
     }
 
     companion object {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configuration-cache=true
 # App version
 lib.groupId = org.apptank.horus
 lib.artifactId = client
-lib.version = 0.18.2
+lib.version = 0.19.0
 
 #Kotlin
 kotlin.code.style=official

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ it could have breaking changes in the API.
   - [Force synchronization](#force-synchronization)
   - [Validate if exists data to synchronize](#validate-if-exists-data-to-synchronize)
   - [Get the last synchronization date](#get-the-last-synchronization-date)
+  - [Query queued actions](#query-queued-actions)
 - [Authentication](#authentication)
   - [Setup access token](#setup-access-token)
   - [Clear session](#clear-session)
@@ -578,8 +579,7 @@ val fileReference = HorusDataFacade.uploadFile(fileData)
 
 val fileUrl = HorusDataFacade.getFileUrl(fileReference)
 
-```  
-
+```
 
 ## Utilities
 
@@ -618,6 +618,45 @@ timestamp in seconds.
 
 ```kotlin
 val lastSyncDate = HorusDataFacade.getLastSyncDate()
+```
+
+### Query queued actions
+
+Use the `queryQueueActions` method to retrieve queued actions stored in the local queue (table `horus_queue_actions`). This is useful to inspect which entities and records have queued operations for synchronization and what type of operations (INSERT, UPDATE, DELETE, MOVE) will be processed.
+
+Parameters:
+- `entityNames: List<String>` — list of entities to include in the query.
+- `dataFilter: Map<String, Any?>` — optional map of key-values used to filter the action JSON payload (uses `json_extract` in SQL).
+- `minDate: LocalDate` — minimum date (inclusive) used to filter actions. Combined with `timeZone` to convert to epoch seconds.
+- `maxDate: LocalDate?` — optional maximum date (inclusive). If `null`, the implementation uses `minDate` as the upper bound (query matches that exact day).
+- `timeZone: TimeZone` — timezone used to interpret dates when converting to epoch seconds.
+
+Returns:
+- `DataResult<List<Horus.QueueAction>>` — on success returns a list of `Horus.QueueAction(entity, id, type)`.
+
+Example:
+
+```kotlin
+val timeZone = TimeZone.of("America/Bogota")
+val minDate = LocalDate(2026, 5, 21)
+
+val result = HorusDataFacade.queryQueueActions(
+  entityNames = listOf("measures"),
+  dataFilter = emptyMap(),
+  minDate = minDate,
+  maxDate = null,
+  timeZone = timeZone
+)
+
+result.fold({ actions ->
+  actions.forEach {
+    println("Entity: ${it.entity}, id: ${it.id}, type: ${it.type}")
+  }
+}, { error ->
+  // Handle error
+})
+
+
 ```
 
 ## Authentication


### PR DESCRIPTION
# v0.19.0
- Added `queryQueueActions` to `HorusDataFacade`.
  - New method to query queued actions stored in the local queue (table `horus_queue_actions`).
  - Supports filtering by:
    - `entityNames`: list of entity names to include.
    - `dataFilter`: map of json-extracted attributes to match against action data.
    - `minDate` and optional `maxDate`: date range (inclusive) used with a timezone to convert to epoch seconds.
    - `timeZone`: timezone used to convert LocalDate to epoch boundaries.
  - Returns a list of `Horus.QueueAction` with fields `(entity, id, type)` where `type` maps to the exposed `ActionType` (INSERT, UPDATE, DELETE, MOVE).
  - Behavior notes:
    - If `maxDate` is `null`, the implementation uses `minDate` as the upper bound (the query matches that exact day).
    - `dataFilter` values are compared using `json_extract(horus_queue_actions.data, '$.<key>')` in SQL.